### PR TITLE
ci: fix by creating plt files before test run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,9 @@ jobs:
           otp-version: ${{matrix.pair.otp}}
           elixir-version: ${{matrix.pair.elixir}}
 
-      - run: mix deps.get --only test
+      - run: mix deps.get
       - run: mix deps.compile
+      - name: Create PLT file (needed for tests)
+        run: MIX_ENV=test mix dialyzer --plt
       - run: mix test
       - run: MIX_ENV=prod_test mix test

--- a/test/test/mockable_test.exs
+++ b/test/test/mockable_test.exs
@@ -67,7 +67,7 @@ defmodule MockableTest do
     return_fail_line = function_lines.dialyzer_return_fail + 1
 
     assert [
-             {:warn_failing_call, {~c"test/support/client.ex", {_line, _col}},
+             {:warn_failing_call, {~c"test/support/client.ex", _location},
               {:call,
                [
                  Client,
@@ -82,7 +82,7 @@ defmodule MockableTest do
            ] = warning_for_line(client_warnings, argument_fail_line)
 
     assert [
-             {:warn_failing_call, {~c"test/support/client.ex", {_line, _col}},
+             {:warn_failing_call, {~c"test/support/client.ex", _location},
               {:call,
                [
                  :erlang,


### PR DESCRIPTION
- `mix test` requires plt file to already exist